### PR TITLE
feat: narrow repository scope, add loading logs, and enrich analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Optional: Gemini API key
+VITE_GEMINI_API_KEY=your_gemini_api_key_here
+
+# Optional: Any OpenAI-compatible Chat Completions endpoint
+VITE_OPENAI_API_BASE_URL=https://api.openai.com
+VITE_OPENAI_API_PATH=/v1/chat/completions
+VITE_OPENAI_API_KEY=your_openai_compatible_api_key_here
+VITE_OPENAI_MODEL=gpt-4o-mini
+# VITE_OPENAI_ORG=org_xxx

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Local environment file (example provided as .env.example)
+.env

--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import { ProjectGallery } from './components/ProjectGallery';
 import { AdvancedInsights } from './components/AdvancedInsights';
 import { AiIdentity } from './components/AiIdentity';
 import { ScrollReveal } from './components/ScrollReveal';
+import { MobilePagedContent } from './components/MobilePagedContent';
 import { fetchGitHubData, processLanguageData, analyzeUserData } from './services/githubService';
 import { generatePersonaAnalysis } from './services/geminiService';
 import { audioService } from './services/audioService';
@@ -56,6 +57,7 @@ export default function App() {
   const [isDemo, setIsDemo] = useState(false);
   const [isMuted, setIsMuted] = useState(true); // Default muted
   const [showLogin, setShowLogin] = useState(false); // Controls login form visibility/animation
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
 
   const appendLoadingLog = (message: string) => {
     const stamp = new Date().toLocaleTimeString('zh-CN', { hour12: false });
@@ -77,6 +79,20 @@ export default function App() {
       window.removeEventListener('click', initAudio);
       window.removeEventListener('keydown', initAudio);
     };
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(max-width: 768px)');
+    const updateViewport = () => setIsMobileViewport(mediaQuery.matches);
+    updateViewport();
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', updateViewport);
+      return () => mediaQuery.removeEventListener('change', updateViewport);
+    }
+
+    mediaQuery.addListener(updateViewport);
+    return () => mediaQuery.removeListener(updateViewport);
   }, []);
 
   const toggleMute = () => {
@@ -373,6 +389,111 @@ export default function App() {
     window.history.replaceState({}, document.title, window.location.pathname);
   };
 
+  const reportSections = userData && analysis ? [
+    {
+      id: 'hero',
+      delay: 0,
+      content: <Hero user={userData} t={t} />
+    },
+    ...(aiPersona ? [{
+      id: 'ai-identity',
+      delay: 200,
+      content: <AiIdentity persona={aiPersona} t={t} />
+    }] : []),
+    {
+      id: 'metrics',
+      delay: 0,
+      content: (
+        <MetricsGrid
+          totalContributions={userData.contributionsCollection.contributionCalendar.totalContributions}
+          commits={userData.contributionsCollection.totalCommitContributions}
+          issues={userData.contributionsCollection.totalIssueContributions}
+          prs={userData.contributionsCollection.totalPullRequestContributions}
+          reviews={userData.contributionsCollection.totalPullRequestReviewContributions}
+          t={t}
+        />
+      )
+    },
+    {
+      id: 'language',
+      delay: 0,
+      content: <LanguageChart languages={languages} t={t} />
+    },
+    {
+      id: 'heatmap',
+      delay: 0,
+      content: <Heatmap calendar={userData.contributionsCollection.contributionCalendar} t={t} />
+    },
+    {
+      id: 'pr-analysis',
+      delay: 0,
+      content: <PrAnalysis analysis={analysis} t={t} />
+    },
+    {
+      id: 'contribution-breakdown',
+      delay: 0,
+      content: <ContributionBreakdown analysis={analysis} t={t} />
+    },
+    {
+      id: 'advanced-insights',
+      delay: 0,
+      content: <AdvancedInsights analysis={analysis} t={t} />
+    },
+    {
+      id: 'achievements',
+      delay: 0,
+      content: <Achievements analysis={analysis} t={t} />
+    },
+    {
+      id: 'community',
+      delay: 0,
+      content: <CommunitySection analysis={analysis} organizations={userData.organizations} t={t} />
+    },
+    {
+      id: 'projects',
+      delay: 0,
+      content: <ProjectGallery analysis={analysis} t={t} />
+    },
+    {
+      id: 'actions',
+      delay: 300,
+      content: (
+        <div className="flex flex-wrap justify-center gap-4 mb-8 md:mb-12 hide-on-screenshot">
+          <button
+            onClick={handleSaveImage}
+            disabled={savingImage || isSharing}
+            onMouseEnter={() => audioService.playHover()}
+            className="flex items-center gap-2 text-xs border bg-black text-primary border-primary hover:bg-primary hover:text-black px-4 py-2 rounded transition-all font-bold shadow-neon disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Camera className="w-4 h-4" />
+            {savingImage ? t.controls.capturing : t.controls.snapshot}
+          </button>
+
+          {!isDemo && (
+            <button
+              onClick={handleShare}
+              disabled={isSharing || savingImage}
+              onMouseEnter={() => audioService.playHover()}
+              className={`flex items-center gap-2 text-xs border px-4 py-2 rounded transition-all font-bold shadow-neon disabled:opacity-50 disabled:cursor-not-allowed ${shareSuccess ? 'bg-white text-black border-white' : 'bg-black text-blue-400 border-blue-400 hover:bg-blue-400 hover:text-black'}`}
+            >
+              <Share2 className="w-4 h-4" />
+              {isSharing ? t.controls.sharing : (shareSuccess ? t.controls.linkCopied : t.controls.share)}
+            </button>
+          )}
+
+          <button
+            onClick={handleTerminate}
+            disabled={savingImage || isSharing}
+            onMouseEnter={() => audioService.playHover()}
+            className="text-xs text-primary/40 hover:text-primary border border-primary/20 hover:border-primary px-4 py-2 rounded transition-all bg-black/50"
+          >
+            {t.controls.terminate}
+          </button>
+        </div>
+      )
+    }
+  ] : [];
+
   return (
     <Layout 
       userData={userData} 
@@ -421,107 +542,17 @@ export default function App() {
 
       {userData && analysis && !loading && (
         <>
-        <div className="flex flex-col gap-8 md:gap-12">
-          {/* Identity - Top Section */}
-          <ScrollReveal>
-            <Hero user={userData} t={t} />
-          </ScrollReveal>
-
-          {/* AI Identity Dossier */}
-          {aiPersona && (
-            <ScrollReveal delay={200}>
-              <AiIdentity persona={aiPersona} t={t} />
-            </ScrollReveal>
-          )}
-
-          {/* Core Metrics & Annual Output */}
-          <ScrollReveal>
-            <MetricsGrid 
-              totalContributions={userData.contributionsCollection.contributionCalendar.totalContributions}
-              commits={userData.contributionsCollection.totalCommitContributions}
-              issues={userData.contributionsCollection.totalIssueContributions}
-              prs={userData.contributionsCollection.totalPullRequestContributions}
-              reviews={userData.contributionsCollection.totalPullRequestReviewContributions}
-              t={t}
-            />
-          </ScrollReveal>
-
-          {/* Language Analysis */}
-          <ScrollReveal>
-            <LanguageChart languages={languages} t={t} />
-          </ScrollReveal>
-
-          {/* Heatmap */}
-          <ScrollReveal>
-            <Heatmap calendar={userData.contributionsCollection.contributionCalendar} t={t} />
-          </ScrollReveal>
-
-          {/* PR Efficiency */}
-          <ScrollReveal>
-            <PrAnalysis analysis={analysis} t={t} />
-          </ScrollReveal>
-
-          {/* Contribution Types */}
-          <ScrollReveal>
-            <ContributionBreakdown analysis={analysis} t={t} />
-          </ScrollReveal>
-
-          {/* Advanced Repo Intelligence */}
-          <ScrollReveal>
-            <AdvancedInsights analysis={analysis} t={t} />
-          </ScrollReveal>
-
-          {/* Achievements */}
-          <ScrollReveal>
-            <Achievements analysis={analysis} t={t} />
-          </ScrollReveal>
-
-          {/* Community & Influence */}
-          <ScrollReveal>
-            <CommunitySection analysis={analysis} organizations={userData.organizations} t={t} />
-          </ScrollReveal>
-
-          {/* Projects & Topics */}
-          <ScrollReveal>
-             <ProjectGallery analysis={analysis} t={t} />
-          </ScrollReveal>
-
-          <ScrollReveal delay={300}>
-            {/* Action Buttons - Hidden in Screenshot */}
-            <div className="flex flex-wrap justify-center gap-4 mb-8 md:mb-12 hide-on-screenshot">
-              <button 
-                onClick={handleSaveImage}
-                disabled={savingImage || isSharing}
-                onMouseEnter={() => audioService.playHover()}
-                className="flex items-center gap-2 text-xs border bg-black text-primary border-primary hover:bg-primary hover:text-black px-4 py-2 rounded transition-all font-bold shadow-neon disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <Camera className="w-4 h-4" />
-                {savingImage ? t.controls.capturing : t.controls.snapshot}
-              </button>
-
-              {!isDemo && (
-                <button 
-                  onClick={handleShare}
-                  disabled={isSharing || savingImage}
-                  onMouseEnter={() => audioService.playHover()}
-                  className={`flex items-center gap-2 text-xs border px-4 py-2 rounded transition-all font-bold shadow-neon disabled:opacity-50 disabled:cursor-not-allowed ${shareSuccess ? 'bg-white text-black border-white' : 'bg-black text-blue-400 border-blue-400 hover:bg-blue-400 hover:text-black'}`}
-                >
-                  <Share2 className="w-4 h-4" />
-                  {isSharing ? t.controls.sharing : (shareSuccess ? t.controls.linkCopied : t.controls.share)}
-                </button>
-              )}
-              
-              <button 
-                onClick={handleTerminate}
-                disabled={savingImage || isSharing}
-                onMouseEnter={() => audioService.playHover()}
-                className="text-xs text-primary/40 hover:text-primary border border-primary/20 hover:border-primary px-4 py-2 rounded transition-all bg-black/50"
-              >
-                {t.controls.terminate}
-              </button>
-            </div>
-          </ScrollReveal>
-        </div>
+        {isMobileViewport ? (
+          <MobilePagedContent sections={reportSections.map(section => section.content)} />
+        ) : (
+          <div className="flex flex-col gap-8 md:gap-12">
+            {reportSections.map(section => (
+              <ScrollReveal key={section.id} delay={section.delay}>
+                {section.content}
+              </ScrollReveal>
+            ))}
+          </div>
+        )}
           <div className="relative border-t border-primary/20 bg-black/90 py-6 text-center relative z-10">
             <div className="max-w-7xl mx-auto flex flex-col items-center gap-4">
               <div className="flex items-center gap-2 text-primary/60 font-mono text-xs">

--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import { CommunitySection } from './components/CommunitySection';
 import { PrAnalysis } from './components/PrAnalysis';
 import { ContributionBreakdown } from './components/ContributionBreakdown';
 import { ProjectGallery } from './components/ProjectGallery';
+import { AdvancedInsights } from './components/AdvancedInsights';
 import { AiIdentity } from './components/AiIdentity';
 import { ScrollReveal } from './components/ScrollReveal';
 import { fetchGitHubData, processLanguageData, analyzeUserData } from './services/githubService';
@@ -48,12 +49,18 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadingText, setLoadingText] = useState<string>(t.loading.init);
+  const [loadingLogs, setLoadingLogs] = useState<string[]>([]);
   const [savingImage, setSavingImage] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
   const [shareSuccess, setShareSuccess] = useState(false);
   const [isDemo, setIsDemo] = useState(false);
   const [isMuted, setIsMuted] = useState(true); // Default muted
   const [showLogin, setShowLogin] = useState(false); // Controls login form visibility/animation
+
+  const appendLoadingLog = (message: string) => {
+    const stamp = new Date().toLocaleTimeString('zh-CN', { hour12: false });
+    setLoadingLogs(prev => [...prev, `[${stamp}] ${message}`].slice(-8));
+  };
 
   // Initialize Audio Context on first interaction
   useEffect(() => {
@@ -82,14 +89,18 @@ export default function App() {
   const loadSharedReport = async (username: string) => {
     setLoading(true);
     setLoadingText(t.loading.retrieving);
+    setLoadingLogs([]);
+    appendLoadingLog(`开始读取共享年报：@${username}`);
     setIsDemo(true); // Treat as demo/read-only
     setShowLogin(false); // Ensure login is hidden while loading
 
     try {
+      appendLoadingLog('正在连接云端归档接口...');
         const response = await fetch(`${API_BASE}/read?key=${username}`);
         if (!response.ok) {
             throw new Error(response.status === 404 ? 'Report not found in archive' : 'Data corruption detected');
         }
+      appendLoadingLog('归档数据读取成功，正在解析...');
         
         const responseJson = await response.json();
         // Use loose typing to extract potential AI cache
@@ -108,6 +119,7 @@ export default function App() {
         // Calculate derived data
         const processedLangs = processLanguageData(data.repositories?.nodes);
         const analysisResult = analyzeUserData(data, t);
+        appendLoadingLog('统计分析完成，正在构建报告...');
 
         setUserData(data);
         setLanguages(processedLangs);
@@ -116,18 +128,22 @@ export default function App() {
         // If we found cached AI persona, use it directly. Otherwise try to generate.
         if (cachedPersona) {
             setAiPersona(cachedPersona);
+          appendLoadingLog('已加载缓存 AI 档案。');
         } else {
             // Attempt to generate AI persona using fallback (no api key on shared view)
             try {
                 const persona = await generatePersonaAnalysis(data, analysisResult, processedLangs, lang);
                 setAiPersona(persona);
+                appendLoadingLog('AI 档案生成完成。');
             } catch (aiErr) {
                 console.warn("Shared view AI skipped:", aiErr);
+                appendLoadingLog('AI 档案生成失败，已跳过。');
             }
         }
 
     } catch (err: any) {
         setError(err.message || 'Connection failed');
+          appendLoadingLog(`读取失败：${err.message || 'Connection failed'}`);
         setShowLogin(true); // Show login on error so user isn't stuck
     } finally {
         setLoading(false);
@@ -199,7 +215,9 @@ export default function App() {
     audioService.playStartup();
     setLoading(true);
     setError(null);
+    setLoadingLogs([]);
     setLoadingText(t.loading.handshake);
+    appendLoadingLog('握手初始化完成。');
     setShowLogin(false); // Hide login form
     
     const isDemoLogin = token === 'demo';
@@ -208,11 +226,16 @@ export default function App() {
     try {
       // 1. Fetch GitHub Data
       setLoadingText(t.loading.connecting);
-      const data = await fetchGitHubData(token, username);
+      appendLoadingLog('准备拉取 GitHub 数据...');
+      const data = await fetchGitHubData(token, username, (msg) => {
+        appendLoadingLog(msg);
+      });
+      appendLoadingLog('GitHub 数据拉取完成。');
       
       // Calculate derived data immediately for AI context
       const processedLangs = processLanguageData(data.repositories?.nodes);
       const analysisResult = analyzeUserData(data, t);
+      appendLoadingLog('基础统计分析完成。');
 
       setUserData(data);
       setLanguages(processedLangs);
@@ -222,15 +245,19 @@ export default function App() {
       let persona = null;
       if (enableAi) {
         setLoadingText(t.loading.profile);
+        appendLoadingLog('开始生成 AI 档案...');
         try {
           // Pass pre-calculated stats to optimized generator
           persona = await generatePersonaAnalysis(data, analysisResult, processedLangs, lang);
           setAiPersona(persona);
+          appendLoadingLog('AI 档案生成成功。');
         } catch (aiErr) {
           console.error("AI Generation failed", aiErr);
+          appendLoadingLog('AI 档案生成失败，已降级为纯数据报告。');
         }
       } else {
         setAiPersona(null);
+        appendLoadingLog('已跳过 AI 档案生成。');
       }
 
       // 3. Cache the results (Only if NOT demo)
@@ -239,12 +266,15 @@ export default function App() {
           userData: data,
           aiPersona: persona
         }));
+        appendLoadingLog('本地缓存写入完成。');
       }
 
     } catch (err: any) {
       setError(err.message || 'Connection failed');
+      appendLoadingLog(`连接失败：${err.message || 'Connection failed'}`);
       setShowLogin(true); // Re-show login on failure
     } finally {
+      appendLoadingLog('流程结束，正在渲染报告视图。');
       setLoading(false);
     }
   };
@@ -366,6 +396,16 @@ export default function App() {
           <div className="font-mono text-primary tracking-widest text-sm animate-pulse">
             {loadingText}
           </div>
+
+          <div className="w-full max-w-2xl bg-black/40 border border-primary/20 p-3">
+            <div className="text-[10px] text-primary/70 uppercase tracking-widest mb-2">{t.loading.logTitle}</div>
+            <div className="font-mono text-[10px] text-gray-300 space-y-1 max-h-40 overflow-y-auto custom-scrollbar">
+              {(loadingLogs.length > 0 ? loadingLogs : [t.loading.waiting]).map((line, idx) => (
+                <div key={`${line}-${idx}`} className="truncate">{line}</div>
+              ))}
+            </div>
+          </div>
+
           <div className="w-64 h-1 bg-surface-light overflow-hidden">
             <div className="h-full bg-primary animate-[loading_2s_ease-in-out_infinite] w-full origin-left scale-x-0"></div>
           </div>
@@ -424,6 +464,11 @@ export default function App() {
           {/* Contribution Types */}
           <ScrollReveal>
             <ContributionBreakdown analysis={analysis} t={t} />
+          </ScrollReveal>
+
+          {/* Advanced Repo Intelligence */}
+          <ScrollReveal>
+            <AdvancedInsights analysis={analysis} t={t} />
           </ScrollReveal>
 
           {/* Achievements */}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Preview URL: [Amery2010's CyberGit Report](https://cybergit.u14.app/#Amery2010)
 *   **Cyberpunk UI/UX**: Matrix rain canvas effects, CRT scanlines, neon glows, and immersive audio SFX (typing, hovering, booting).
 *   **Deep Data Analysis**: Backend logic to calculate streaks, refactor ratios, and merge velocities from raw GraphQL nodes.
 *   **AI Persona Generation**: Uses Google Gemini to generate a unique narrative profile describing your coding soul.
-*   **Contribution Heatmap**: A custom-built, glowing activity grid for the year 2025.
+*   **Contribution Heatmap**: A dynamic, glowing activity grid auto-detected from your report year.
 *   **3D Tech Cloud**: Interactive tag sphere visualizing your top topics.
 *   **Export & Share**: Generate a high-quality PNG snapshot of your report or share via a unique uplink URL.
 
@@ -58,7 +58,7 @@ Preview URL: [Amery2010's CyberGit Report](https://cybergit.u14.app/#Amery2010)
 *   **Frontend**: React 19, TypeScript
 *   **Styling**: Tailwind CSS (with custom animations and fonts)
 *   **Data Fetching**: GitHub GraphQL API
-*   **AI**: Google GenAI SDK (`@google/genai`)
+*   **AI**: Google GenAI SDK (`@google/genai`) + OpenAI-Compatible Chat Completions API
 *   **Audio**: Web Audio API (Custom oscillator synthesizer)
 
 ## 🔌 Installation & Access
@@ -68,6 +68,7 @@ Preview URL: [Amery2010's CyberGit Report](https://cybergit.u14.app/#Amery2010)
 *   Node.js (v18+)
 *   A GitHub Personal Access Token (Scope: `read:user`, `read:org`, `repo`)
 *   (Optional) Google Gemini API Key for AI features
+*   (Optional) Any OpenAI-compatible API endpoint and key
 
 ### Local Deployment
 
@@ -87,6 +88,15 @@ Preview URL: [Amery2010's CyberGit Report](https://cybergit.u14.app/#Amery2010)
     ```env
     # Optional: For local AI generation without proxy
     VITE_GEMINI_API_KEY=your_gemini_api_key_here
+
+    # Optional: Any OpenAI-compatible API (Chat Completions)
+    # Examples: OpenAI, Azure OpenAI-compatible gateway, vLLM, OneAPI, LocalAI, etc.
+    VITE_OPENAI_API_BASE_URL=https://api.openai.com
+    VITE_OPENAI_API_PATH=/v1/chat/completions
+    VITE_OPENAI_API_KEY=your_openai_compatible_api_key_here
+    VITE_OPENAI_MODEL=gpt-4o-mini
+    # Optional org header
+    # VITE_OPENAI_ORG=org_xxx
     ```
 
 4.  **Initiate System**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,7 +49,7 @@
 *   **赛博朋克 UI/UX**: 包含黑客帝国式的代码雨 Canvas 特效、CRT 扫描线、霓虹光晕以及沉浸式的音频音效（打字声、悬停声、启动音）。
 *   **深度数据分析**: 后端逻辑负责计算连胜、重构比率以及从原始 GraphQL 节点中提取合并速度。
 *   **AI 人格生成**: 使用 AI 模型生成描述你编程灵魂的独特叙事档案。
-*   **贡献热力图**: 专为 2025 年定制的绿色荧光活动网格。
+*   **贡献热力图**: 自动识别报告年份的绿色荧光活动网格。
 *   **3D 技术云**: 可交互的 3D 标签球，展示你的热门技术栈。
 *   **导出与分享**: 生成高质量的 PNG 报告快照，或通过唯一的上行链路 URL 分享你的档案。
 
@@ -58,7 +58,7 @@
 *   **前端**: React 19, TypeScript
 *   **样式**: Tailwind CSS (配合自定义动画与字体)
 *   **数据源**: GitHub GraphQL API
-*   **AI**: Google GenAI SDK (`@google/genai`)
+*   **AI**: Google GenAI SDK (`@google/genai`) + OpenAI 兼容 Chat Completions API
 *   **音频**: Web Audio API (自定义振荡器合成器)
 
 ## 🔌 安装与接入
@@ -68,6 +68,7 @@
 *   Node.js (v18+)
 *   GitHub Personal Access Token (权限范围: `read:user`, `read:org`, `repo`)
 *   (可选) Google Gemini API Key 用于 AI 功能
+*   (可选) 任意 OpenAI 格式 API 的地址与密钥
 
 ### 本地部署
 
@@ -87,6 +88,15 @@
     ```env
     # 可选：用于本地开发的 Gemini API Key
     VITE_GEMINI_API_KEY=your_gemini_api_key_here
+
+    # 可选：任意 OpenAI 兼容接口（Chat Completions）
+    # 例如：OpenAI、兼容网关、vLLM、OneAPI、LocalAI 等
+    VITE_OPENAI_API_BASE_URL=https://api.openai.com
+    VITE_OPENAI_API_PATH=/v1/chat/completions
+    VITE_OPENAI_API_KEY=your_openai_compatible_api_key_here
+    VITE_OPENAI_MODEL=gpt-4o-mini
+    # 可选组织头
+    # VITE_OPENAI_ORG=org_xxx
     ```
 
 4.  **启动系统**

--- a/components/AdvancedInsights.tsx
+++ b/components/AdvancedInsights.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { AnalysisResult } from '../types';
+import { CountUp } from './Animators';
+import { Radar, ShieldCheck, GitCommitHorizontal, Clock3 } from 'lucide-react';
+import { Translations } from '../translations';
+
+interface AdvancedInsightsProps {
+  analysis: AnalysisResult;
+  t: Translations;
+}
+
+export const AdvancedInsights: React.FC<AdvancedInsightsProps> = ({ analysis, t }) => {
+  const ownershipRatio = analysis.filteredRepoCount > 0
+    ? Math.round((analysis.ownedOrAdminRepoCount / analysis.filteredRepoCount) * 100)
+    : 0;
+
+  const commitCoverage = analysis.filteredRepoCount > 0
+    ? Math.round((analysis.reposWithOwnCommits / analysis.filteredRepoCount) * 100)
+    : 0;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-4 mb-2">
+        <div className="h-[1px] flex-grow bg-primary/20" />
+        <h3 className="text-primary font-bold tracking-widest text-sm uppercase flex items-center gap-2">
+          <Radar className="w-4 h-4" />
+          {t.insights.title}
+        </h3>
+        <div className="h-[1px] flex-grow bg-primary/20" />
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-surface-dark border border-primary/20 p-4 relative overflow-hidden group">
+          <div className="absolute right-0 top-0 p-3 opacity-10 group-hover:opacity-30 transition-opacity">
+            <ShieldCheck className="w-12 h-12 text-green-400" />
+          </div>
+          <div className="text-[10px] text-gray-500 uppercase tracking-widest mb-1">{t.insights.ownershipControl}</div>
+          <div className="text-2xl font-bold text-white">
+            <CountUp end={ownershipRatio} suffix="%" />
+          </div>
+          <div className="text-[9px] text-green-400/70 mt-1">{analysis.ownedOrAdminRepoCount}/{analysis.filteredRepoCount}</div>
+        </div>
+
+        <div className="bg-surface-dark border border-primary/20 p-4 relative overflow-hidden group">
+          <div className="absolute right-0 top-0 p-3 opacity-10 group-hover:opacity-30 transition-opacity">
+            <GitCommitHorizontal className="w-12 h-12 text-primary" />
+          </div>
+          <div className="text-[10px] text-gray-500 uppercase tracking-widest mb-1">{t.insights.commitCoverage}</div>
+          <div className="text-2xl font-bold text-white">
+            <CountUp end={commitCoverage} suffix="%" />
+          </div>
+          <div className="text-[9px] text-primary/70 mt-1">{analysis.reposWithOwnCommits}/{analysis.filteredRepoCount}</div>
+        </div>
+
+        <div className="bg-surface-dark border border-primary/20 p-4 relative overflow-hidden group">
+          <div className="absolute right-0 top-0 p-3 opacity-10 group-hover:opacity-30 transition-opacity">
+            <GitCommitHorizontal className="w-12 h-12 text-blue-400" />
+          </div>
+          <div className="text-[10px] text-gray-500 uppercase tracking-widest mb-1">{t.insights.commitDensity}</div>
+          <div className="text-2xl font-bold text-white">
+            {analysis.commitDensity}
+          </div>
+          <div className="text-[9px] text-blue-400/70 mt-1">{t.insights.perRepo}</div>
+        </div>
+
+        <div className="bg-surface-dark border border-primary/20 p-4 relative overflow-hidden group">
+          <div className="absolute right-0 top-0 p-3 opacity-10 group-hover:opacity-30 transition-opacity">
+            <Clock3 className="w-12 h-12 text-yellow-400" />
+          </div>
+          <div className="text-[10px] text-gray-500 uppercase tracking-widest mb-1">{t.insights.freshness90d}</div>
+          <div className="text-2xl font-bold text-white">
+            <CountUp end={Math.round(analysis.repoFreshnessRatio * 100)} suffix="%" />
+          </div>
+          <div className="text-[9px] text-yellow-400/70 mt-1">{t.insights.activeRecently}</div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -1,5 +1,5 @@
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { ContributionCalendar } from '../types';
 import { useInView } from './Animators';
 import { Calendar } from 'lucide-react';
@@ -37,18 +37,37 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
     return selectedYear;
   }, [calendar.weeks]);
 
-  // Filter by detected dominant year
-  const filteredWeeks = useMemo(() => {
-    return (calendar.weeks || [])
-      .map(week => ({
-        ...week,
-        contributionDays: (week.contributionDays || []).filter(day => {
-          const date = new Date(day.date);
-          return !isNaN(date.getTime()) && date.getFullYear() === targetYear;
-        })
-      }))
-      .filter(week => week.contributionDays.length > 0);
-  }, [calendar.weeks, targetYear]);
+  // Determine available years from the data (descending)
+  const availableYears = useMemo(() => {
+    const s = new Set<number>();
+    (calendar.weeks || []).forEach(week => {
+      (week.contributionDays || []).forEach(day => {
+        const d = new Date(day.date);
+        if (!isNaN(d.getTime())) s.add(d.getFullYear());
+      });
+    });
+    return Array.from(s).sort((a, b) => b - a);
+  }, [calendar.weeks]);
+
+  const currentYear = new Date().getFullYear();
+  const previousYear = currentYear - 1;
+
+  const [selectedYear, setSelectedYear] = useState<number>(previousYear);
+
+  // If previous year has no data, fall back to detected dominant year
+  useEffect(() => {
+    if (availableYears.length === 0) {
+      setSelectedYear(targetYear);
+      return;
+    }
+    if (!availableYears.includes(previousYear)) {
+      setSelectedYear(targetYear);
+    } else {
+      setSelectedYear(previousYear);
+    }
+  }, [availableYears, previousYear, targetYear]);
+
+  
 
   // Determine color intensity based on contribution count
   const getColorClass = (count: number) => {
@@ -64,7 +83,7 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
     const labels: { name: string; weekIndex: number }[] = [];
     let lastMonth = -1;
 
-    filteredWeeks.forEach((week, index) => {
+    filteredWeeksForYear.forEach((week, index) => {
       // Use the first day of the week to determine the month
       const firstDay = week.contributionDays[0];
       if (!firstDay) return;
@@ -83,7 +102,20 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
       }
     });
     return labels;
-  }, [filteredWeeks]);
+  }, [filteredWeeksForYear]);
+
+  // Recompute filteredWeeks for the selected year
+  const filteredWeeksForYear = useMemo(() => {
+    return (calendar.weeks || [])
+      .map(week => ({
+        ...week,
+        contributionDays: (week.contributionDays || []).filter(day => {
+          const date = new Date(day.date);
+          return !isNaN(date.getTime()) && date.getFullYear() === selectedYear;
+        })
+      }))
+      .filter(week => week.contributionDays.length > 0);
+  }, [calendar.weeks, selectedYear]);
 
   return (
     <section className="relative" ref={ref}>
@@ -93,9 +125,26 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
             <Calendar className="w-4 h-4" />
             {t.heatmap.title}
           </h3>
-          <p className="text-[10px] text-gray-500 mt-1 uppercase">{t.heatmap.subtitle} {targetYear}</p>
+          <p className="text-[10px] text-gray-500 mt-1 uppercase">{t.heatmap.subtitle} {selectedYear}</p>
         </div>
-        
+        <div className="flex items-center gap-2 mt-3 md:mt-0">
+          <button
+            onClick={() => setSelectedYear(previousYear)}
+            disabled={!availableYears.includes(previousYear)}
+            className={`text-xs px-3 py-1 rounded ${selectedYear === previousYear ? 'bg-primary text-black' : 'bg-black/40 text-primary'} disabled:opacity-40`}
+          >
+            {previousYear}
+          </button>
+
+          <button
+            onClick={() => setSelectedYear(currentYear)}
+            disabled={!availableYears.includes(currentYear)}
+            className={`text-xs px-3 py-1 rounded ${selectedYear === currentYear ? 'bg-primary text-black' : 'bg-black/40 text-primary'} disabled:opacity-40`}
+          >
+            {currentYear}
+          </button>
+        </div>
+
         <div className="hidden sm:flex items-center gap-2 text-[10px] text-gray-500 mt-4 md:mt-0">
           <span>{t.heatmap.null}</span>
           <div className="flex gap-1">
@@ -110,7 +159,7 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
       </div>
 
       <div className="w-full overflow-x-auto pb-4 custom-scrollbar bg-surface-dark border border-primary/30 p-4 shadow-neon-strong">
-        {filteredWeeks.length === 0 && (
+        {filteredWeeksForYear.length === 0 && (
           <div className="text-center py-8 text-xs text-primary/50 font-mono uppercase tracking-widest">
             {t.tags.noData}
           </div>
@@ -119,7 +168,7 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
         <div className="min-w-max flex flex-col gap-1">
           {/* Month Labels Container */}
           <div className="relative h-4 w-full mb-2">
-            {monthLabels.map((label, i) => (
+              {monthLabels.map((label, i) => (
               <span 
                 key={i}
                 className="absolute text-[10px] text-primary/40 font-mono"
@@ -147,7 +196,7 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
 
             {/* The Grid */}
             <div className="flex-1 flex gap-[3px]">
-              {filteredWeeks.map((week, wIdx) => (
+              {filteredWeeksForYear.map((week, wIdx) => (
                  <div key={wIdx} className="flex flex-col gap-[3px]">
                    {week.contributionDays.map((day, dIdx) => (
                      <div 

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -13,15 +13,42 @@ interface HeatmapProps {
 export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
   const { ref, isInView } = useInView({ threshold: 0.2 });
 
-  // Filter for year 2025 only
+  const targetYear = useMemo(() => {
+    const yearCounter = new Map<number, number>();
+    (calendar.weeks || []).forEach(week => {
+      (week.contributionDays || []).forEach(day => {
+        const date = new Date(day.date);
+        if (isNaN(date.getTime())) return;
+        const year = date.getFullYear();
+        yearCounter.set(year, (yearCounter.get(year) || 0) + 1);
+      });
+    });
+
+    if (yearCounter.size === 0) return new Date().getFullYear();
+
+    let selectedYear = new Date().getFullYear();
+    let maxCount = -1;
+    yearCounter.forEach((count, year) => {
+      if (count > maxCount) {
+        selectedYear = year;
+        maxCount = count;
+      }
+    });
+    return selectedYear;
+  }, [calendar.weeks]);
+
+  // Filter by detected dominant year
   const filteredWeeks = useMemo(() => {
-    return calendar.weeks
+    return (calendar.weeks || [])
       .map(week => ({
         ...week,
-        contributionDays: week.contributionDays.filter(day => day.date.startsWith('2025'))
+        contributionDays: (week.contributionDays || []).filter(day => {
+          const date = new Date(day.date);
+          return !isNaN(date.getTime()) && date.getFullYear() === targetYear;
+        })
       }))
       .filter(week => week.contributionDays.length > 0);
-  }, [calendar.weeks]);
+  }, [calendar.weeks, targetYear]);
 
   // Determine color intensity based on contribution count
   const getColorClass = (count: number) => {
@@ -66,7 +93,7 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
             <Calendar className="w-4 h-4" />
             {t.heatmap.title}
           </h3>
-          <p className="text-[10px] text-gray-500 mt-1 uppercase">{t.heatmap.subtitle}</p>
+          <p className="text-[10px] text-gray-500 mt-1 uppercase">{t.heatmap.subtitle} {targetYear}</p>
         </div>
         
         <div className="hidden sm:flex items-center gap-2 text-[10px] text-gray-500 mt-4 md:mt-0">
@@ -83,6 +110,12 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
       </div>
 
       <div className="w-full overflow-x-auto pb-4 custom-scrollbar bg-surface-dark border border-primary/30 p-4 shadow-neon-strong">
+        {filteredWeeks.length === 0 && (
+          <div className="text-center py-8 text-xs text-primary/50 font-mono uppercase tracking-widest">
+            {t.tags.noData}
+          </div>
+        )}
+
         <div className="min-w-max flex flex-col gap-1">
           {/* Month Labels Container */}
           <div className="relative h-4 w-full mb-2">

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -13,6 +13,17 @@ interface HeatmapProps {
 export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
   const { ref, isInView } = useInView({ threshold: 0.2 });
 
+  // Dev-only debug info to help trace empty-data cases
+  if (typeof window !== 'undefined' && (import.meta as any)?.env?.DEV) {
+    try {
+      const sampleWeeks = (calendar?.weeks || []).slice(0, 3).map(w => (w.contributionDays || []).slice(0,3).map(d=>d.date));
+      // eslint-disable-next-line no-console
+      console.debug('Heatmap debug:', { totalWeeks: (calendar?.weeks || []).length, sampleWeeks });
+    } catch (e) {
+      // ignore
+    }
+  }
+
   const targetYear = useMemo(() => {
     const yearCounter = new Map<number, number>();
     (calendar.weeks || []).forEach(week => {
@@ -67,6 +78,9 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
     }
   }, [availableYears, previousYear, targetYear]);
 
+  const canSelectPreviousYear = availableYears.includes(previousYear);
+  const canSelectCurrentYear = availableYears.includes(currentYear);
+
   
 
   // Determine color intensity based on contribution count
@@ -77,32 +91,6 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
     if (count <= 10) return 'bg-[#009900] border border-primary/40';
     return 'bg-[#00FF41] shadow-neon';
   };
-
-  // Calculate month labels based on filtered data
-  const monthLabels = useMemo(() => {
-    const labels: { name: string; weekIndex: number }[] = [];
-    let lastMonth = -1;
-
-    filteredWeeksForYear.forEach((week, index) => {
-      // Use the first day of the week to determine the month
-      const firstDay = week.contributionDays[0];
-      if (!firstDay) return;
-      
-      const date = new Date(firstDay.date);
-      // Valid date check
-      if (isNaN(date.getTime())) return;
-      
-      const month = date.getMonth();
-      // If month changes or it's the first week, add a label
-      if (month !== lastMonth) {
-        // Use browser locale, or fallback to english short month if needed, but let's stick to simple
-        const monthName = date.toLocaleString('en-US', { month: 'short' }).toUpperCase();
-        labels.push({ name: monthName, weekIndex: index });
-        lastMonth = month;
-      }
-    });
-    return labels;
-  }, [filteredWeeksForYear]);
 
   // Recompute filteredWeeks for the selected year
   const filteredWeeksForYear = useMemo(() => {
@@ -117,6 +105,27 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
       .filter(week => week.contributionDays.length > 0);
   }, [calendar.weeks, selectedYear]);
 
+  // Now that filteredWeeksForYear is defined, re-create monthLabels with correct dependency
+  const monthLabels = useMemo(() => {
+    const labels: { name: string; weekIndex: number }[] = [];
+    let lastMonth = -1;
+
+    filteredWeeksForYear.forEach((week, index) => {
+      const firstDay = week.contributionDays[0];
+      if (!firstDay) return;
+      const date = new Date(firstDay.date);
+      if (isNaN(date.getTime())) return;
+      const month = date.getMonth();
+      if (month !== lastMonth) {
+        const monthName = date.toLocaleString('en-US', { month: 'short' }).toUpperCase();
+        labels.push({ name: monthName, weekIndex: index });
+        lastMonth = month;
+      }
+    });
+    return labels;
+  }, [filteredWeeksForYear]);
+
+
   return (
     <section className="relative" ref={ref}>
       <div className="flex flex-col md:flex-row justify-between items-start mb-6">
@@ -129,17 +138,17 @@ export const Heatmap: React.FC<HeatmapProps> = ({ calendar, t }) => {
         </div>
         <div className="flex items-center gap-2 mt-3 md:mt-0">
           <button
-            onClick={() => setSelectedYear(previousYear)}
-            disabled={!availableYears.includes(previousYear)}
-            className={`text-xs px-3 py-1 rounded ${selectedYear === previousYear ? 'bg-primary text-black' : 'bg-black/40 text-primary'} disabled:opacity-40`}
+            onClick={() => canSelectPreviousYear && setSelectedYear(previousYear)}
+            disabled={!canSelectPreviousYear}
+            className={`text-xs px-3 py-1 rounded ${selectedYear === previousYear ? 'bg-primary text-black' : 'bg-black/40 text-primary'} ${!canSelectPreviousYear ? 'opacity-40 cursor-not-allowed' : ''}`}
           >
             {previousYear}
           </button>
 
           <button
-            onClick={() => setSelectedYear(currentYear)}
-            disabled={!availableYears.includes(currentYear)}
-            className={`text-xs px-3 py-1 rounded ${selectedYear === currentYear ? 'bg-primary text-black' : 'bg-black/40 text-primary'} disabled:opacity-40`}
+            onClick={() => canSelectCurrentYear && setSelectedYear(currentYear)}
+            disabled={!canSelectCurrentYear}
+            className={`text-xs px-3 py-1 rounded ${selectedYear === currentYear ? 'bg-primary text-black' : 'bg-black/40 text-primary'} ${!canSelectCurrentYear ? 'opacity-40 cursor-not-allowed' : ''}`}
           >
             {currentYear}
           </button>

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -87,11 +87,12 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLogin, isLoading, error,
                 <form onSubmit={handleSubmit} className="flex flex-col gap-3">
                     <div className="relative">
                         <input 
-                            type="password"
-                            value={token}
-                            onChange={(e) => { setToken(e.target.value); audioService.playType(); }}
-                            placeholder={t.login.tokenPlaceholder}
-                            className="w-full bg-black border border-primary/30 text-primary p-3 pl-10 focus:outline-none focus:border-primary focus:shadow-[0_0_10px_rgba(0,255,65,0.3)] transition-all font-mono text-xs placeholder:text-primary/30"
+                          type="password"
+                          value={token}
+                          onChange={(e) => { setToken(e.target.value); audioService.playType(); }}
+                          placeholder={t.login.tokenPlaceholder}
+                          autoComplete="new-password"
+                          className="w-full bg-black border border-primary/30 text-primary p-3 pl-10 focus:outline-none focus:border-primary focus:shadow-[0_0_10px_rgba(0,255,65,0.3)] transition-all font-mono text-xs placeholder:text-primary/30"
                         />
                         <KeyRound className="absolute left-3 top-1/2 -translate-y-1/2 text-primary/50 w-4 h-4" />
                     </div>

--- a/components/MobilePagedContent.tsx
+++ b/components/MobilePagedContent.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+interface MobilePagedContentProps {
+  sections: React.ReactNode[];
+}
+
+const MOBILE_RATIO_WIDTH = 9;
+const MOBILE_RATIO_HEIGHT = 16;
+
+const getPageMaxHeight = (): number => {
+  if (typeof window === 'undefined') return 480;
+
+  const ratioHeight = (window.innerWidth * MOBILE_RATIO_HEIGHT) / MOBILE_RATIO_WIDTH;
+  const logicalScreenHeight = Math.min(window.innerHeight, ratioHeight);
+  return Math.max(280, Math.floor(logicalScreenHeight * 0.75));
+};
+
+export const MobilePagedContent: React.FC<MobilePagedContentProps> = ({ sections }) => {
+  const measureRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const [pageMaxHeight, setPageMaxHeight] = useState<number>(getPageMaxHeight);
+  const [sectionHeights, setSectionHeights] = useState<number[]>([]);
+  const [activePage, setActivePage] = useState<number>(0);
+
+  useEffect(() => {
+    const recalc = () => setPageMaxHeight(getPageMaxHeight());
+    recalc();
+    window.addEventListener('resize', recalc);
+    return () => window.removeEventListener('resize', recalc);
+  }, []);
+
+  useLayoutEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      const heights = sections.map((_, index) => {
+        const el = measureRefs.current[index];
+        return el ? Math.ceil(el.getBoundingClientRect().height) : 0;
+      });
+      setSectionHeights(heights);
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [sections, pageMaxHeight]);
+
+  const pageGroups = useMemo<number[][]>(() => {
+    if (sections.length === 0) return [];
+
+    const validHeights = sectionHeights.length === sections.length
+      ? sectionHeights.map(h => (h > 0 ? h : 1))
+      : sections.map(() => Math.max(1, Math.floor(pageMaxHeight / 2)));
+
+    const pages: number[][] = [];
+    let currentPage: number[] = [];
+    let currentHeight = 0;
+
+    validHeights.forEach((height, index) => {
+      const normalizedHeight = Math.min(height, pageMaxHeight);
+
+      if (currentPage.length > 0 && currentHeight + normalizedHeight > pageMaxHeight) {
+        pages.push(currentPage);
+        currentPage = [index];
+        currentHeight = normalizedHeight;
+      } else {
+        currentPage.push(index);
+        currentHeight += normalizedHeight;
+      }
+    });
+
+    if (currentPage.length > 0) pages.push(currentPage);
+
+    return pages.length > 0 ? pages : [sections.map((_, i) => i)];
+  }, [sectionHeights, sections, pageMaxHeight]);
+
+  useEffect(() => {
+    setActivePage(prev => Math.min(prev, Math.max(0, pageGroups.length - 1)));
+  }, [pageGroups.length]);
+
+  if (sections.length === 0) return null;
+
+  const totalPages = pageGroups.length;
+  const currentIndexes = pageGroups[activePage] || [];
+
+  return (
+    <div className="md:hidden w-full relative">
+      <div className="absolute -z-10 opacity-0 pointer-events-none w-full" aria-hidden>
+        {sections.map((section, index) => (
+          <div
+            key={`measure-${index}`}
+            ref={(el) => {
+              measureRefs.current[index] = el;
+            }}
+            className="mb-6"
+          >
+            {section}
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="w-full border border-primary/30 bg-black/50 rounded-lg overflow-hidden"
+        style={{
+          aspectRatio: `${MOBILE_RATIO_WIDTH} / ${MOBILE_RATIO_HEIGHT}`,
+          maxHeight: `${pageMaxHeight}px`
+        }}
+      >
+        <div className="h-full overflow-y-auto custom-scrollbar p-2">
+          <div className="flex flex-col gap-6">
+            {currentIndexes.map(index => (
+              <div key={`page-${activePage}-section-${index}`}>
+                {sections[index]}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="mt-3 flex items-center justify-between px-1">
+          <button
+            onClick={() => setActivePage(p => Math.max(0, p - 1))}
+            disabled={activePage === 0}
+            className="text-[10px] px-2 py-1 border border-primary/30 text-primary disabled:opacity-30 rounded"
+          >
+            PREV
+          </button>
+
+          <div className="flex items-center gap-1.5">
+            {pageGroups.map((_, idx) => (
+              <button
+                key={`dot-${idx}`}
+                onClick={() => setActivePage(idx)}
+                aria-label={`Go to page ${idx + 1}`}
+                className={`w-2 h-2 rounded-full transition-all ${idx === activePage ? 'bg-primary' : 'bg-primary/30'}`}
+              />
+            ))}
+          </div>
+
+          <button
+            onClick={() => setActivePage(p => Math.min(totalPages - 1, p + 1))}
+            disabled={activePage === totalPages - 1}
+            className="text-[10px] px-2 py-1 border border-primary/30 text-primary disabled:opacity-30 rounded"
+          >
+            NEXT
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1703 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@google/genai':
+        specifier: ^1.34.0
+        version: 1.41.0
+      html-to-image:
+        specifier: ^1.11.11
+        version: 1.11.13
+      lucide-react:
+        specifier: ^0.554.0
+        version: 0.554.0(react@19.2.4)
+      react:
+        specifier: ^19.2.3
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.11
+      '@vitejs/plugin-react':
+        specifier: ^5.0.0
+        version: 5.1.4(vite@6.4.1(@types/node@22.19.11))
+      typescript:
+        specifier: ~5.8.2
+        version: 5.8.3
+      vite:
+        specifier: ^6.2.0
+        version: 6.4.1(@types/node@22.19.11)
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@google/genai@1.41.0':
+    resolution: {integrity: sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  '@vitejs/plugin-react@5.1.4':
+    resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.9.19:
+    resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
+    hasBin: true
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  caniuse-lite@1.0.30001769:
+    resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  electron-to-chromium@1.5.286:
+    resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    hasBin: true
+
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-network-error@1.3.0:
+    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.554.0:
+    resolution: {integrity: sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.6':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@google/genai@1.41.0':
+    dependencies:
+      google-auth-library: 10.5.0
+      p-retry: 7.1.1
+      protobufjs: 7.5.4
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.11':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitejs/plugin-react@5.1.4(vite@6.4.1(@types/node@22.19.11))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 6.4.1(@types/node@22.19.11)
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.9.19: {}
+
+  bignumber.js@9.3.1: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.9.19
+      caniuse-lite: 1.0.30001769
+      electron-to-chromium: 1.5.286
+      node-releases: 2.0.27
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  caniuse-lite@1.0.30001769: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  data-uri-to-buffer@4.0.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  electron-to-chromium@1.5.286: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  extend@3.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  gensync@1.0.0-beta.2: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  html-to-image@1.11.13: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-network-error@1.3.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json5@2.2.3: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  long@5.3.2: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.554.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@7.1.2: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  node-releases@2.0.27: {}
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.0
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.11
+      long: 5.3.2
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.4: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  safe-buffer@5.2.1: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  typescript@5.8.3: {}
+
+  undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@6.4.1(@types/node@22.19.11):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.11
+      fsevents: 2.3.3
+
+  web-streams-polyfill@3.3.3: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
+
+  ws@8.19.0: {}
+
+  yallist@3.1.1: {}

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -116,70 +116,76 @@ export const generatePersonaAnalysis = async (
   if (apiKey) {
     const ai = new GoogleGenAI({ apiKey });
     
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash",
-      contents: JSON.stringify(summaryData),
-      config: {
-        systemInstruction: systemPrompt,
-        responseMimeType: "application/json",
-        responseSchema: {
-          type: Type.OBJECT,
-          properties: {
-            veteran: {
-              type: Type.OBJECT,
-              properties: {
-                title: { type: Type.STRING },
-                yearsSince: { type: Type.NUMBER },
-                location: { type: Type.STRING },
-                description: { type: Type.STRING },
+    try {
+      const response = await ai.models.generateContent({
+        model: "gemini-2.5-flash",
+        contents: JSON.stringify(summaryData),
+        config: {
+          systemInstruction: systemPrompt,
+          responseMimeType: "application/json",
+          responseSchema: {
+            type: Type.OBJECT,
+            properties: {
+              veteran: {
+                type: Type.OBJECT,
+                properties: {
+                  title: { type: Type.STRING },
+                  yearsSince: { type: Type.NUMBER },
+                  location: { type: Type.STRING },
+                  description: { type: Type.STRING },
+                }
+              },
+              specialist: {
+                type: Type.OBJECT,
+                properties: {
+                  primaryLang: { type: Type.STRING },
+                  secondaryLangs: { type: Type.ARRAY, items: { type: Type.STRING } },
+                  nicheLang: { type: Type.STRING },
+                  description: { type: Type.STRING },
+                }
+              },
+              creator: {
+                type: Type.OBJECT,
+                properties: {
+                  topProjects: { type: Type.ARRAY, items: { type: Type.STRING } },
+                  description: { type: Type.STRING },
+                }
+              },
+              aiSurfer: {
+                type: Type.OBJECT,
+                properties: {
+                  keywords: { type: Type.ARRAY, items: { type: Type.STRING } },
+                  description: { type: Type.STRING },
+                }
+              },
+              collaborator: {
+                 type: Type.OBJECT,
+                 properties: {
+                   orgNames: { type: Type.ARRAY, items: { type: Type.STRING } },
+                   description: { type: Type.STRING }
+                 }
+              },
+              finalPersona: {
+                 type: Type.OBJECT,
+                 properties: {
+                   title: { type: Type.STRING },
+                   keywords: { type: Type.ARRAY, items: { type: Type.STRING } },
+                   summary: { type: Type.STRING }
+                 }
               }
-            },
-            specialist: {
-              type: Type.OBJECT,
-              properties: {
-                primaryLang: { type: Type.STRING },
-                secondaryLangs: { type: Type.ARRAY, items: { type: Type.STRING } },
-                nicheLang: { type: Type.STRING },
-                description: { type: Type.STRING },
-              }
-            },
-            creator: {
-              type: Type.OBJECT,
-              properties: {
-                topProjects: { type: Type.ARRAY, items: { type: Type.STRING } },
-                description: { type: Type.STRING },
-              }
-            },
-            aiSurfer: {
-              type: Type.OBJECT,
-              properties: {
-                keywords: { type: Type.ARRAY, items: { type: Type.STRING } },
-                description: { type: Type.STRING },
-              }
-            },
-            collaborator: {
-               type: Type.OBJECT,
-               properties: {
-                 orgNames: { type: Type.ARRAY, items: { type: Type.STRING } },
-                 description: { type: Type.STRING }
-               }
-            },
-            finalPersona: {
-               type: Type.OBJECT,
-               properties: {
-                 title: { type: Type.STRING },
-                 keywords: { type: Type.ARRAY, items: { type: Type.STRING } },
-                 summary: { type: Type.STRING }
-               }
             }
           }
         }
-      }
-    });
+      });
 
-    const text = response.text;
-    if (!text) throw new Error("No analysis generated");
-    return JSON.parse(text) as AiPersona;
+      const text = response.text;
+      if (!text) throw new Error("No analysis generated");
+      return JSON.parse(text) as AiPersona;
+    } catch (err) {
+      // Gemini-specific problems (invalid API key, bad request, etc.) should not crash the app
+      // Fall through to the next fallback provider and log a concise warning for debugging
+      console.warn('Gemini generation failed, falling back to other AI providers:', err);
+    }
   }
 
   // 2. Try any OpenAI-compatible API configured by env

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,6 +2,20 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { UserData, AiPersona, Language, AnalysisResult, ProcessedLanguage } from '../types';
 
+const getEnv = (key: string): string | undefined => {
+  const viteEnv = (typeof import.meta !== 'undefined' ? (import.meta as any).env : undefined) || {};
+  const processEnv = (globalThis as any)?.process?.env || {};
+  return viteEnv[key] || processEnv[key];
+};
+
+const extractJsonPayload = (raw: string): string => {
+  const cleaned = raw.replace(/```json/g, '').replace(/```/g, '').trim();
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  if (start >= 0 && end > start) return cleaned.slice(start, end + 1);
+  return cleaned;
+};
+
 // Mock AI Persona for Demo Mode
 const getMockPersona = (lang: string): AiPersona => {
     const isZh = lang === 'zh';
@@ -98,7 +112,7 @@ export const generatePersonaAnalysis = async (
   `;
 
   // 1. Try Gemini if API Key is present
-  const apiKey = process.env.API_KEY || process.env.VITE_GEMINI_API_KEY
+  const apiKey = getEnv('API_KEY') || getEnv('VITE_GEMINI_API_KEY');
   if (apiKey) {
     const ai = new GoogleGenAI({ apiKey });
     
@@ -168,7 +182,66 @@ export const generatePersonaAnalysis = async (
     return JSON.parse(text) as AiPersona;
   }
 
-  // 2. Try Custom API Proxy
+  // 2. Try any OpenAI-compatible API configured by env
+  const openaiBaseUrl = getEnv('VITE_OPENAI_API_BASE_URL');
+  const openaiApiKey = getEnv('VITE_OPENAI_API_KEY');
+  const openaiModel = getEnv('VITE_OPENAI_MODEL') || 'gpt-4o-mini';
+  const openaiPath = getEnv('VITE_OPENAI_API_PATH') || '/v1/chat/completions';
+
+  if (openaiBaseUrl && openaiApiKey) {
+    const normalizedBase = openaiBaseUrl.replace(/\/$/, '');
+    const normalizedPath = openaiPath.startsWith('/') ? openaiPath : `/${openaiPath}`;
+    const endpoint = `${normalizedBase}${normalizedPath}`;
+
+    const jsonStructure = {
+      veteran: { title: "string", yearsSince: 0, location: "string", description: "string" },
+      specialist: { primaryLang: "string", secondaryLangs: ["string"], nicheLang: "string", description: "string" },
+      creator: { topProjects: ["string"], description: "string" },
+      aiSurfer: { keywords: ["string"], description: "string" },
+      collaborator: { orgNames: ["string"], description: "string" },
+      finalPersona: { title: "string", keywords: ["string"], summary: "string" }
+    };
+
+    const openaiPrompt = `${systemPrompt}
+
+    RETURN ONLY PURE JSON matching the structure below. Do not wrap in markdown code blocks.
+    Structure:
+    ${JSON.stringify(jsonStructure, null, 2)}
+    `;
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${openaiApiKey}`,
+          ...(getEnv('VITE_OPENAI_ORG') ? { 'OpenAI-Organization': getEnv('VITE_OPENAI_ORG') as string } : {}),
+        },
+        body: JSON.stringify({
+          model: openaiModel,
+          messages: [
+            { role: 'system', content: openaiPrompt },
+            { role: 'user', content: JSON.stringify(summaryData) }
+          ],
+          response_format: { type: 'json_object' }
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`OpenAI-compatible API Error: ${response.status} ${response.statusText}`);
+      }
+
+      const json = await response.json();
+      const content = json?.choices?.[0]?.message?.content;
+      if (!content) throw new Error('No content from OpenAI-compatible API');
+
+      return JSON.parse(extractJsonPayload(content)) as AiPersona;
+    } catch (err) {
+      console.warn('OpenAI-compatible API failed, falling back:', err);
+    }
+  }
+
+  // 3. Try Custom API Proxy
   try {
     const response = await fetch('https://cybergit-api.u14.app/api/ai', {
       method: 'POST',
@@ -191,7 +264,7 @@ export const generatePersonaAnalysis = async (
     console.warn("Custom API Proxy failed, falling back to Pollinations:", err);
   }
 
-  // 3. Fallback to Pollinations.ai (OpenAI Compatible)
+  // 4. Fallback to Pollinations.ai (OpenAI Compatible)
   console.log("Using Pollinations.ai fallback (openai-fast)...");
   
   const jsonStructure = {
@@ -237,9 +310,7 @@ export const generatePersonaAnalysis = async (
     if (!content) throw new Error("No content from Pollinations AI");
 
     // Clean markdown code blocks if present (common in LLM output even when asked for JSON)
-    content = content.replace(/```json/g, '').replace(/```/g, '').trim();
-
-    return JSON.parse(content) as AiPersona;
+    return JSON.parse(extractJsonPayload(content)) as AiPersona;
   } catch (err) {
     console.error("Pollinations AI failed:", err);
     throw new Error("Failed to generate persona via Fallback AI.");

--- a/services/githubService.ts
+++ b/services/githubService.ts
@@ -1,4 +1,4 @@
-import { UserData, ProcessedLanguage, RepositoryNode, AnalysisResult, ContributionDay, TopicStat } from '../types';
+import { UserData, ProcessedLanguage, RepositoryNode, AnalysisResult, ContributionDay, TopicStat, ContributionCalendar } from '../types';
 import { Translations } from '../translations';
 
 const GITHUB_GRAPHQL_API = 'https://api.github.com/graphql';
@@ -368,6 +368,83 @@ query ViewerAnnualReport($from: DateTime!, $to: DateTime!) {
 }
 `;
 
+const USER_PREVIOUS_YEAR_CALENDAR_QUERY = `
+query UserPreviousYearCalendar($login: String!, $from: DateTime!, $to: DateTime!) {
+  user(login: $login) {
+    contributionsCollection(from: $from, to: $to) {
+      contributionCalendar {
+        totalContributions
+        weeks {
+          contributionDays {
+            contributionCount
+            date
+            color
+            weekday
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const VIEWER_PREVIOUS_YEAR_CALENDAR_QUERY = `
+query ViewerPreviousYearCalendar($from: DateTime!, $to: DateTime!) {
+  viewer {
+    contributionsCollection(from: $from, to: $to) {
+      contributionCalendar {
+        totalContributions
+        weeks {
+          contributionDays {
+            contributionCount
+            date
+            color
+            weekday
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const mergeContributionCalendars = (
+  currentCalendar: ContributionCalendar,
+  previousCalendar: ContributionCalendar | null
+): ContributionCalendar => {
+  if (!previousCalendar) return currentCalendar;
+
+  const seenDates = new Set<string>();
+  const mergedWeeks: ContributionCalendar['weeks'] = [];
+
+  const pushUniqueWeeks = (weeks: ContributionCalendar['weeks']) => {
+    (weeks || []).forEach(week => {
+      const uniqueDays = (week.contributionDays || []).filter(day => {
+        if (!day?.date || seenDates.has(day.date)) return false;
+        seenDates.add(day.date);
+        return true;
+      });
+
+      if (uniqueDays.length > 0) {
+        mergedWeeks.push({ contributionDays: uniqueDays });
+      }
+    });
+  };
+
+  // Keep chronological order: previous year first, current year second
+  pushUniqueWeeks(previousCalendar.weeks || []);
+  pushUniqueWeeks(currentCalendar.weeks || []);
+
+  const totalContributions = mergedWeeks
+    .flatMap(week => week.contributionDays || [])
+    .reduce((sum, day) => sum + (day.contributionCount || 0), 0);
+
+  return {
+    totalContributions,
+    weeks: mergedWeeks
+  };
+};
+
 // --- FETCH FUNCTION ---
 
 export const fetchGitHubData = async (
@@ -379,10 +456,14 @@ export const fetchGitHubData = async (
     return new Promise((resolve) => setTimeout(() => resolve(MOCK_DATA), 1500));
   }
 
-  // Default to year 2025 (or current year)
+  // Main report must stay within 1 year due to GitHub contributionsCollection constraints.
+  // Previous-year heatmap data is fetched via a second calendar-only query.
   const currentYear = new Date().getFullYear();
+  const previousYear = currentYear - 1;
   const from = `${currentYear}-01-01T00:00:00Z`;
   const to = `${currentYear}-12-31T23:59:59Z`;
+  const previousYearFrom = `${previousYear}-01-01T00:00:00Z`;
+  const previousYearTo = `${previousYear}-12-31T23:59:59Z`;
 
   // IF no username is provided, we use the VIEWER query.
   // This is CRITICAL because querying 'viewer' allows access to private stats/repos 
@@ -425,6 +506,47 @@ export const fetchGitHubData = async (
 
   if (!userData) {
     throw new Error(`User ${username || 'authenticated user'} not found or accessible.`);
+  }
+
+  // Try to extend heatmap with previous-year calendar data.
+  // If this fails, keep current-year data without blocking the whole report.
+  try {
+    onProgress?.('正在补充上一年热力图数据...');
+
+    const calendarQuery = isViewerQuery ? VIEWER_PREVIOUS_YEAR_CALENDAR_QUERY : USER_PREVIOUS_YEAR_CALENDAR_QUERY;
+    const calendarVariables: any = {
+      from: previousYearFrom,
+      to: previousYearTo
+    };
+
+    if (!isViewerQuery) {
+      calendarVariables.login = username;
+    }
+
+    const calendarResponse = await fetch(GITHUB_GRAPHQL_API, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ query: calendarQuery, variables: calendarVariables }),
+    });
+
+    if (calendarResponse.ok) {
+      const calendarJson = await calendarResponse.json();
+      const calendarRoot = isViewerQuery ? calendarJson?.data?.viewer : calendarJson?.data?.user;
+      const previousCalendar = calendarRoot?.contributionsCollection?.contributionCalendar as ContributionCalendar | undefined;
+
+      if (previousCalendar && userData?.contributionsCollection?.contributionCalendar) {
+        userData.contributionsCollection.contributionCalendar = mergeContributionCalendars(
+          userData.contributionsCollection.contributionCalendar,
+          previousCalendar
+        );
+        onProgress?.('上一年热力图数据已合并。');
+      }
+    }
+  } catch (calendarErr) {
+    console.warn('Failed to fetch previous-year calendar, fallback to current-year only:', calendarErr);
   }
 
   onProgress?.('正在根据 owner/admin/commit 规则筛选仓库...');

--- a/services/githubService.ts
+++ b/services/githubService.ts
@@ -676,6 +676,37 @@ export const analyzeUserData = (data: UserData, t: Translations): AnalysisResult
     .slice(0, 15) // Increased limit for cloud
     .map(([name, count]) => ({ name, count }));
 
+  let resilientTopTopics = topTopics;
+  if (resilientTopTopics.length === 0) {
+    const fallbackMap = new Map<string, number>();
+
+    repoNodes.forEach(repo => {
+      const lang = repo.primaryLanguage?.name;
+      if (lang) {
+        fallbackMap.set(lang.toLowerCase(), (fallbackMap.get(lang.toLowerCase()) || 0) + 2);
+      }
+
+      (repo.languages?.edges || []).forEach(edge => {
+        const name = edge.node?.name;
+        if (name) {
+          fallbackMap.set(name.toLowerCase(), (fallbackMap.get(name.toLowerCase()) || 0) + 1);
+        }
+      });
+
+      const repoName = (repo.name || '').toLowerCase();
+      repoName.split(/[-_.\s]+/).forEach(token => {
+        if (token.length >= 3) {
+          fallbackMap.set(token, (fallbackMap.get(token) || 0) + 1);
+        }
+      });
+    });
+
+    resilientTopTopics = Array.from(fallbackMap.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 15)
+      .map(([name, count]) => ({ name, count }));
+  }
+
   // --- Community & Classification Analysis ---
   let openSourcePRs = 0;
   let orgPRs = 0;
@@ -786,7 +817,7 @@ export const analyzeUserData = (data: UserData, t: Translations): AnalysisResult
     personalPRs,
     impactRepo,
     topOrganization,
-    topTopics,
+    topTopics: resilientTopTopics,
     topReposList
   };
 };

--- a/services/githubService.ts
+++ b/services/githubService.ts
@@ -3,6 +3,53 @@ import { Translations } from '../translations';
 
 const GITHUB_GRAPHQL_API = 'https://api.github.com/graphql';
 
+const buildRepoKey = (owner: string | undefined, name: string | undefined): string => {
+  if (!owner || !name) return '';
+  return `${owner.toLowerCase()}/${name.toLowerCase()}`;
+};
+
+const filterRepositoriesByOwnershipAndCommits = (userData: UserData): UserData => {
+  const login = (userData.login || '').toLowerCase();
+  const commitRepos = userData.contributionsCollection?.commitContributionsByRepository || [];
+  const sourceRepos = userData.repositories?.nodes || [];
+
+  const commitRepoKeys = new Set<string>();
+  const commitRepoNames = new Set<string>();
+
+  commitRepos.forEach(repoContrib => {
+    const commits = repoContrib.contributions?.nodes || [];
+    const totalCommits = commits.reduce((sum, c) => sum + (c.commitCount || 0), 0);
+    if (totalCommits <= 0) return;
+
+    const owner = repoContrib.repository?.owner?.login;
+    const name = repoContrib.repository?.name;
+    const key = buildRepoKey(owner, name);
+
+    if (key) commitRepoKeys.add(key);
+    if (name) commitRepoNames.add(name.toLowerCase());
+  });
+
+  const filteredNodes = sourceRepos.filter(repo => {
+    const ownerLogin = repo.owner?.login;
+    const isOwner = (ownerLogin || '').toLowerCase() === login;
+    const isAdmin = (repo.viewerPermission || '').toUpperCase() === 'ADMIN';
+
+    const key = buildRepoKey(ownerLogin, repo.name);
+    const hasCommits = (key && commitRepoKeys.has(key)) || commitRepoNames.has((repo.name || '').toLowerCase());
+
+    return isOwner || isAdmin || hasCommits;
+  });
+
+  return {
+    ...userData,
+    repositories: {
+      ...userData.repositories,
+      totalCount: filteredNodes.length,
+      nodes: filteredNodes
+    }
+  };
+};
+
 // --- MOCK DATA FOR DEMO ---
 const generateMockCalendar = () => {
   const weeks = [];
@@ -204,6 +251,9 @@ const USER_DATA_FRAGMENT = `
         repository {
           name
           isPrivate
+          owner {
+            login
+          }
           primaryLanguage {
              name
              color
@@ -269,10 +319,14 @@ const USER_DATA_FRAGMENT = `
         url
         description
         isPrivate
+        viewerPermission
         stargazerCount
         forkCount
         pushedAt
         diskUsage
+        owner {
+          login
+        }
         primaryLanguage {
           name
           color
@@ -316,7 +370,11 @@ query ViewerAnnualReport($from: DateTime!, $to: DateTime!) {
 
 // --- FETCH FUNCTION ---
 
-export const fetchGitHubData = async (token: string, username?: string): Promise<UserData> => {
+export const fetchGitHubData = async (
+  token: string,
+  username?: string,
+  onProgress?: (message: string) => void
+): Promise<UserData> => {
   if (token === 'demo') {
     return new Promise((resolve) => setTimeout(() => resolve(MOCK_DATA), 1500));
   }
@@ -330,6 +388,7 @@ export const fetchGitHubData = async (token: string, username?: string): Promise
   // This is CRITICAL because querying 'viewer' allows access to private stats/repos 
   // that querying 'user(login: me)' might hide depending on token scope nuance.
   const isViewerQuery = !username || username.trim() === '';
+  onProgress?.(isViewerQuery ? '正在读取当前登录用户数据...' : `正在读取用户 @${username} 的公开数据...`);
 
   const query = isViewerQuery ? VIEWER_REPORT_QUERY : ANNUAL_REPORT_QUERY;
   const variables: any = { from, to };
@@ -337,6 +396,8 @@ export const fetchGitHubData = async (token: string, username?: string): Promise
   if (!isViewerQuery) {
     variables.login = username;
   }
+
+  onProgress?.('正在请求 GitHub GraphQL 接口...');
 
   const response = await fetch(GITHUB_GRAPHQL_API, {
     method: 'POST',
@@ -351,6 +412,8 @@ export const fetchGitHubData = async (token: string, username?: string): Promise
     throw new Error(`GitHub API Error: ${response.statusText}`);
   }
 
+  onProgress?.('接口返回成功，正在解析响应...');
+
   const json = await response.json();
   
   if (json.errors) {
@@ -364,7 +427,11 @@ export const fetchGitHubData = async (token: string, username?: string): Promise
     throw new Error(`User ${username || 'authenticated user'} not found or accessible.`);
   }
 
-  return userData;
+  onProgress?.('正在根据 owner/admin/commit 规则筛选仓库...');
+  const normalized = filterRepositoriesByOwnershipAndCommits(userData as UserData);
+  onProgress?.(`筛选完成：保留 ${normalized.repositories.nodes.length} 个有效仓库。`);
+
+  return normalized;
 };
 
 // --- HELPERS ---
@@ -472,6 +539,35 @@ export const analyzeUserData = (data: UserData, t: Translations): AnalysisResult
   const totalRepos = data.repositories?.totalCount || repoNodes.length;
   const avgRepoSize = totalRepos > 0 ? Math.round(totalDiskUsage / totalRepos) : 0;
   const privateRepoRatio = totalRepos > 0 ? privateRepoCount / totalRepos : 0;
+
+  const commitRepos = contributionCollection.commitContributionsByRepository || [];
+  const reposWithOwnCommits = commitRepos.filter(repoContrib => {
+    const nodes = repoContrib.contributions?.nodes || [];
+    return nodes.reduce((sum, c) => sum + (c.commitCount || 0), 0) > 0;
+  }).length;
+
+  const ownedOrAdminRepoCount = repoNodes.filter(repo => {
+    const isOwner = (repo.owner?.login || '').toLowerCase() === (data.login || '').toLowerCase();
+    const isAdmin = (repo.viewerPermission || '').toUpperCase() === 'ADMIN';
+    return isOwner || isAdmin;
+  }).length;
+
+  const ninetyDaysAgo = new Date();
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+  const recentActiveRepoCount = repoNodes.filter(repo => {
+    if (!repo.pushedAt) return false;
+    return new Date(repo.pushedAt).getTime() >= ninetyDaysAgo.getTime();
+  }).length;
+
+  const collaborationRepos = repoNodes.filter(repo => {
+    return (repo.owner?.login || '').toLowerCase() !== (data.login || '').toLowerCase();
+  }).length;
+
+  const commitDensity = reposWithOwnCommits > 0
+    ? parseFloat(((contributionCollection.totalCommitContributions || 0) / reposWithOwnCommits).toFixed(1))
+    : 0;
+  const collaborationIndex = totalRepos > 0 ? collaborationRepos / totalRepos : 0;
+  const repoFreshnessRatio = totalRepos > 0 ? recentActiveRepoCount / totalRepos : 0;
 
   // --- Time Distribution ---
   const commitContributions = contributionCollection.commitContributionsByRepository || [];
@@ -679,6 +775,12 @@ export const analyzeUserData = (data: UserData, t: Translations): AnalysisResult
     totalForks,
     avgRepoSize,
     privateRepoRatio,
+    filteredRepoCount: totalRepos,
+    ownedOrAdminRepoCount,
+    reposWithOwnCommits,
+    commitDensity,
+    collaborationIndex,
+    repoFreshnessRatio,
     openSourcePRs,
     orgPRs,
     personalPRs,

--- a/translations.ts
+++ b/translations.ts
@@ -64,7 +64,7 @@ export const translations = {
     },
     heatmap: {
       title: 'Temporal_Activity_Log',
-      subtitle: 'Activity Log // 2025 Cycle',
+      subtitle: 'Activity Log // Annual Cycle',
       null: 'NULL',
       max: 'MAX'
     },
@@ -252,7 +252,7 @@ export const translations = {
     },
     heatmap: {
       title: '时间活动日志',
-      subtitle: '活动日志 // 2025 周期',
+      subtitle: '活动日志 // 年度周期',
       null: '零',
       max: '最强'
     },

--- a/translations.ts
+++ b/translations.ts
@@ -16,7 +16,9 @@ export const translations = {
       connecting: 'CONNECTING NEURAL NETWORKS...',
       profile: 'AI DECIPHERING PROFILE...',
       init: 'INITIALIZING CONNECTION...',
-      retrieving: 'RETRIEVING ARCHIVED DATA...'
+      retrieving: 'RETRIEVING ARCHIVED DATA...',
+      logTitle: 'Pipeline Logs',
+      waiting: 'Waiting for network signal...'
     },
     layout: {
       title: 'GITHUB USER REPORT',
@@ -145,6 +147,15 @@ export const translations = {
       title: 'Contribution_Spectrum',
       ops: 'Ops'
     },
+    insights: {
+      title: 'Repository_Intelligence',
+      ownershipControl: 'Ownership / Admin Control',
+      commitCoverage: 'Commit Coverage',
+      commitDensity: 'Commits Density',
+      freshness90d: 'Freshness (90d)',
+      perRepo: 'commits per active repo',
+      activeRecently: 'recently active repositories'
+    },
     projects: {
       title: 'Project_Matrix',
       topRepos: 'Top_Repositories',
@@ -193,7 +204,9 @@ export const translations = {
       connecting: '连接神经网络...',
       profile: 'AI 正在解密档案...',
       init: '正在初始化连接...',
-      retrieving: '正在检索归档数据...'
+      retrieving: '正在检索归档数据...',
+      logTitle: '拉取日志',
+      waiting: '等待网络信号中...'
     },
     layout: {
       title: 'GITHUB 用户年报',
@@ -321,6 +334,15 @@ export const translations = {
     breakdown: {
       title: '贡献光谱',
       ops: '次操作'
+    },
+    insights: {
+      title: '仓库智能分析',
+      ownershipControl: 'Owner / 管理员控制率',
+      commitCoverage: '提交覆盖率',
+      commitDensity: '提交密度',
+      freshness90d: '近 90 天活跃度',
+      perRepo: '每个活跃仓库平均提交',
+      activeRecently: '近期有推送的仓库占比'
     },
     projects: {
       title: '项目矩阵',

--- a/types.ts
+++ b/types.ts
@@ -38,6 +38,7 @@ export interface RepositoryNode {
   url: string;
   description: string | null;
   isPrivate: boolean;
+  viewerPermission?: string | null;
   stargazerCount: number;
   forkCount: number;
   pushedAt: string;
@@ -93,6 +94,9 @@ export interface RepoCommitContribution {
   repository: {
     name: string;
     isPrivate: boolean;
+    owner?: {
+      login: string;
+    };
     primaryLanguage: LanguageNode | null;
   };
   contributions: {
@@ -206,6 +210,14 @@ export interface AnalysisResult {
   totalForks: number;
   avgRepoSize: number; // KB
   privateRepoRatio: number; // 0-1
+
+  // Repository Scope Intelligence
+  filteredRepoCount: number;
+  ownedOrAdminRepoCount: number;
+  reposWithOwnCommits: number;
+  commitDensity: number;
+  collaborationIndex: number; // 0-1
+  repoFreshnessRatio: number; // 0-1
   
   // Community Stats
   openSourcePRs: number; 


### PR DESCRIPTION
## Summary
- Restrict repository statistics to repos where the logged-in user is owner/admin or has commit records
- Exclude org-member repositories where the logged-in user has no commit activity
- Add live loading logs during data fetching so users can see progress
- Add an advanced insights section with richer analytics dimensions
- Fix heatmap year switching by supporting previous-year data without violating GitHub GraphQL 1-year window limits
- Add mobile dynamic paging with TSX-only implementation, using a 9:16 viewport reference and 75% screen-height cap

## Details
- Added repository filtering and fetch progress callback in `services/githubService.ts`
- Extended year handling for heatmap data:
  - Main annual query remains within current year
  - Added previous-year calendar-only query
  - Merged calendars by unique `date` with total recalculation
- Updated `components/Heatmap.tsx`:
  - Improved year availability detection
  - Disabled unavailable year buttons to prevent false "data missing" interaction
- Added `components/MobilePagedContent.tsx` and integrated in `App.tsx`:
  - Mobile-only paged rendering branch
  - Dynamic section measurement and automatic pagination
  - PREV/NEXT + dot navigation
- Kept desktop behavior unchanged with existing scroll reveal flow

## Verification
- Build passed (`pnpm build`)
- Manual regression checks completed for:
  - Heatmap switching between current/previous year
  - Mobile pagination rendering and navigation
